### PR TITLE
make this tldr more readable and improve understanding

### DIFF
--- a/tldr
+++ b/tldr
@@ -96,7 +96,7 @@ quotation() {
 
 list_item() {
     local line="$*"
-    echo "$line$reset"
+    echo "$bold$line$reset"
 }
 
 code() {
@@ -108,7 +108,7 @@ code() {
     line=${line//\{\{/$italic}
     line=${line//\}\}/$eitalic}
 
-    echo "$bold$line$reset"
+    echo "    $line$reset"
 }
 
 text() {


### PR DESCRIPTION
Whenever I open a tldr page it is confusing for me to know whether or not the list item describes the following or previous command due to the bold fond used.

I think is important to stablish the hierarchy Description -> command to improve understanding and reduce time when looking for a fast answer.
