### PR TITLE
Added option to create a local cache of files for offline access

### DIFF
--- a/tldr
+++ b/tldr
@@ -18,13 +18,16 @@ config() {
 
     platform=$(get_platform)
     base_url="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-    index_url="http://tldr-pages.github.io/assets/index.json"
+    index_url="http://tldr.sh/assets/index.json"
     index="$configdir/index.json"
-    cache_days=14
+    cache_days=`14
     force_update=''
 
     #check if config folder exists, otherwise create it
-    [ -d "$configdir" ] || mkdir -p "$configdir"; cache_tldr
+    if [ ! -d "$configdir" ] ; then
+      mkdir -p "$configdir" 
+      cache_tldr
+    fi
 
     [ ! -f $index ] && update_index
     auto_update_index

--- a/tldr
+++ b/tldr
@@ -24,7 +24,10 @@ config() {
     force_update=''
 
     #check if config folder exists, otherwise create it
-    [ -d "$configdir" ] || mkdir -p "$configdir"; cache_tldr
+    if [ ! -d "$configdir" ]; then 
+        mkdir -p "$configdir"
+        cache_tldr
+    fi
 
     [ ! -f $index ] && update_index
     auto_update_index

--- a/tldr
+++ b/tldr
@@ -168,18 +168,17 @@ path_for_cmd() {
     fi
 }
 
-# cache a local copy of the tldrpage if it does not exist
+# cache a local copy of the tldrpage 
 cache_tldr() {
-    declare in_vars=$(</dev/stdin) 
-    
-    for word in $in_vars; do 
-        local p="$(path_for_cmd $word)"
-        cached="$configdir/$p"
-        recent "$cached" || {
-            mkdir -p $(dirname $cached)
-            curl -sf -o "$cached" "$base_url/$p"
-        }
-    done 
+    set +f 
+    curl -sfL https://github.com/tldr-pages/tldr/tarball/master > $configdir/tldr-pages.tar.gz
+    tar xzf "$configdir"/tldr-pages.tar.gz -C "$configdir"
+    mv -f "$configdir"/tldr-pages-tldr-*/pages/* "$configdir"
+
+    # clean up temporary files
+    rm -r "$configdir"/tldr-pages*
+
+    set -f 
 }
 
 # return the local cached copy of the tldrpage, or retrieve and cache from github
@@ -239,7 +238,7 @@ do
             platform=$1
             ;;
         -c|--cache)
-            tr '{' '\n' < "$configdir/index.json" | cut -d '"' -f4 | cache_tldr 
+            cache_tldr 
             exit 0
             ;;
         -*)

--- a/tldr
+++ b/tldr
@@ -168,6 +168,20 @@ path_for_cmd() {
     fi
 }
 
+# cache a local copy of the tldrpage if it does not exist
+cache_tldr() {
+    declare in_vars=$(</dev/stdin) 
+    
+    for word in $in_vars; do 
+        local p="$(path_for_cmd $word)"
+        cached="$configdir/$p"
+        recent "$cached" || {
+            mkdir -p $(dirname $cached)
+            curl -sf -o "$cached" "$base_url/$p"
+        }
+    done 
+}
+
 # return the local cached copy of the tldrpage, or retrieve and cache from github
 get_tldr() {
     local p="$(path_for_cmd $1)"
@@ -192,6 +206,7 @@ USAGE: $cmd [options] <command>
     -l, --list:      show all available pages
     -p, --platform:  show page from specific platform rather than autodetecting
     -u, --update:    update, force retrieving latest copies of locally cached files
+    -c, --cache:     cache a local copy of all tldr commands
     -h, -?, --help:  this help overview
 
 <command>
@@ -223,12 +238,17 @@ do
             shift
             platform=$1
             ;;
+        -c|--cache)
+            tr '{' '\n' < "$configdir/index.json" | cut -d '"' -f4 | cache_tldr 
+            exit 0
+            ;;
         -*)
             usage
             ;;
         *)
             page=${1:-''}
             ;;
+                        
     esac
     shift
 done

--- a/tldr
+++ b/tldr
@@ -24,7 +24,7 @@ config() {
     force_update=''
 
     #check if config folder exists, otherwise create it
-    [ -d "$configdir" ] || mkdir -p "$configdir"
+    [ -d "$configdir" ] || mkdir -p "$configdir"; cache_tldr
 
     [ ! -f $index ] && update_index
     auto_update_index


### PR DESCRIPTION
Right now the script doesn't work if you're offline, unless you have read the tldr for that command before.  I added an option to download a copy of every command so that it will work reliably when offline. 