### PR TITLE
Use index.json from tldr.sh

### DIFF
--- a/tldr
+++ b/tldr
@@ -18,7 +18,7 @@ config() {
 
     platform=$(get_platform)
     base_url="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-    index_url="http://tldr-pages.github.io/assets/index.json"
+    index_url="https://tldr.sh/assets/index.json"
     index="$configdir/index.json"
     cache_days=14
     force_update=''


### PR DESCRIPTION
Solves same problem as #16, i.e. no tldr page can ever be found. The difference is that this PR changes the url instead of adding the -L option to curl. I think this approach is a bit better because
* tldr.sh seems to be the new canonical domain -- tldr-pages.github.io redirects to tldr.sh
* https is used

Commit msg below
--- 
The index.json file has been 301 redirected to a new url, which caused
curl to fetch nginx's default 301 template to be saved instead of the
actual index. With the index file malformed, no tldr page could ever be
found.

The old url (at github.io) redirects to the new location (at tldr.sh),
but curl doesn't follow redirections without -L.

New url also uses https.