### PR TITLE
Bugfix/update index url

### DIFF
--- a/tldr
+++ b/tldr
@@ -18,7 +18,7 @@ config() {
 
     platform=$(get_platform)
     base_url="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-    index_url="http://tldr-pages.github.io/assets/index.json"
+    index_url="http://tldr.sh/assets/index.json"
     index="$configdir/index.json"
     cache_days=14
     force_update=''


### PR DESCRIPTION
When I run `tldr curl`, the `$configdir/index.json` shows a redirect message.

```
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

There are two solutions for this,

1. change the index url (this PR)

2. use `-L location` in the curl command

   ```
   $ curl -L tldr-pages.github.io http://tldr-pages.github.io/assets/index.json
   ```

I think we can simply change the url instead of following the redirect every time when we need `index.json`