### PR TITLE
Fixed json index link.

### DIFF
--- a/tldr
+++ b/tldr
@@ -18,7 +18,7 @@ config() {
 
     platform=$(get_platform)
     base_url="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-    index_url="http://tldr-pages.github.io/assets/index.json"
+    index_url="http://tldr.sh/assets/index.json"
     index="$configdir/index.json"
     cache_days=14
     force_update=''


### PR DESCRIPTION
As index was transfered to https://tldr.sh/, client was unable to get index from old url: http://tldr-pages.github.io/assets/index.json