### PR TITLE
Fix index.json retrieval

### DIFF
--- a/tldr
+++ b/tldr
@@ -17,7 +17,7 @@ config() {
 
     platform=$(get_platform)
     base_url="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-    index_url="http://tldr.sh/assets/index.json"
+    index_url="https://raw.githubusercontent.com/tldr-pages/tldr-pages.github.io/master/assets/index.json"
     index="$configdir/index.json"
     cache_days=14
     force_update=''


### PR DESCRIPTION
Update the link to the commands index to avoid getting errors updating the
cache:
> ./tldr
Could not download index from http://tldr.sh/assets/index.json

Signed-off-by: Razvan Stefanescu <stefanescu.razvan@gmail.com>