### PR TITLE
README now gives a better configuration advice for PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then try using the command! If you get an error such as _-bash: tldr: command no
 you may need to add `~/bin` to your `$PATH`. On OSX edit `~/.bash_profile`
 (`~/.bashrc` on Linux), and add the following line to the bottom of the file:
 ```bash
-export PATH=~/bin:$PATH
+export PATH="$PATH:~/bin"
 ```
 
 If you'd like to enable shell completion (eg. `tldr w<tab><tab>` to get a


### PR DESCRIPTION
If you put anything dangerous in your `~/bin`, like a new command `ls` with built-in crap (such as a nice `rm -rf *`), it will be used instead of the real one. So be careful with $PATH. This commit fixes this in the README.