### PR TITLE
Use $base_url in fetch_tldr

### DIFF
--- a/tldr
+++ b/tldr
@@ -248,7 +248,7 @@ get_tldr() {
 }
 
 fetch_tldr() {
-	curl -sf "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/{$platform,common}/$1.md"
+	curl -sf "$base_url/{$platform,common}/$1.md"
 }
 
 list_pages() {


### PR DESCRIPTION
Note: this PR adds no new functionality, it just reuses `$base_url` which is defined in the `config()` function.
