### PR TITLE
fix `tldr -u`, use `unzip -o` to "overwrite existing files without prompting"

### DIFF
--- a/tldr
+++ b/tldr
@@ -256,7 +256,7 @@ update_tldr_cache() {
 	if cache; then
 		mkdir -p "$(page_cache)"
 		Get "$(upstream_pages)" > "$(cache_dir)/tldr.zip"
-		silent unzip -d "$(page_cache)" -u "$(cache_dir)/tldr.zip"
+		silent unzip -o -d "$(page_cache)" -u "$(cache_dir)/tldr.zip"
 	fi
 }
 


### PR DESCRIPTION
after `tldr -u`, `unzip` without `-o` will prompt:
```
Archive:  /home/xyz/.cache//tldr/tldr.zip
replace /home/xyz/.cache//tldr/page-source/pages/android/settings.md? [y]es, [n]o, [A]ll, [N]one, [r]ename:
...
```
it requires user input to overwrite existing files\
the prompt is hidden by `silent`, thus the script will show nothing and stop here

use `-o` to "overwrite existing files without prompting"