### PR TITLE
Set eitalic as default TLDR_EPARAM only if TLDR_PARAM is italic

### DIFF
--- a/tldr
+++ b/tldr
@@ -370,10 +370,9 @@ term() {
 			sdescription) term ${TLDR_DESCRIPTION:-reset} ;;
 			scode)        term ${TLDR_CODE:-bold} ;;
 			sparam)       term ${TLDR_PARAM:-italic} ;;
-			eparam)       local ender=`(printf %s "$TLDR_PARAM" | grep -qw italic) && echo eitalic`
- 			              term ${TLDR_EPARAM:-$ender} ;;
+			eparam)       term ${TLDR_EPARAM:-eitalic} ;;
 		esac
-	done
+	done 2>/dev/null # sliencing tput's complaining
 }
 
 # heading formats its arguments as a heading.

--- a/tldr
+++ b/tldr
@@ -370,7 +370,8 @@ term() {
 			sdescription) term ${TLDR_DESCRIPTION:-reset} ;;
 			scode)        term ${TLDR_CODE:-bold} ;;
 			sparam)       term ${TLDR_PARAM:-italic} ;;
-			eparam)       term ${TLDR_EPARAM:-eitalic} ;;
+			eparam)       local ender=`(printf %s "$TLDR_PARAM" | grep -qw italic) && echo eitalic`
+ 			              term ${TLDR_EPARAM:-$ender} ;;
 		esac
 	done
 }


### PR DESCRIPTION
Setting `TLDR_PARAM` without 'italic' and leaving `TLDR_EPARAM` undefined makes `TLDR_EPARAM` have default value 'eitalic'
As my terminal did not support italics, every execution of tldr emitted a message saying `tput: unknown terminfo capability 'ZH'`
So, I `TLDR_EPARAM` defaults to italic only when it is empty, and `TLDR_PARAM` does not contain 'italic' option.