### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/tldr
+++ b/tldr
@@ -147,11 +147,11 @@ check_requirements() {
 # constants and read-only values
 
 base_url() {
-	echo https://raw.githubusercontent.com/tldr-pages/tldr/master/pages
+	echo https://raw.githubusercontent.com/tldr-pages/tldr/main/pages
 }
 
 upstream_pages() {
-	echo https://raw.githubusercontent.com/tldr-pages/tldr-pages.github.io/master/assets/tldr.zip
+	echo https://raw.githubusercontent.com/tldr-pages/tldr-pages.github.io/main/assets/tldr.zip
 }
 
 # cache_dir returns the base path for caching tldr data files.


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).