### PR TITLE
fix cat outputing error when user supplies a nonexistant command

### DIFF
--- a/tldr
+++ b/tldr
@@ -109,7 +109,7 @@ main() {
 		exit 0
 	fi
 
-	tldr=$(get_page_md "$Cmd")
+	tldr=$(get_page_md "$Cmd" 2>/dev/null)
 	if [ -z "$tldr" ]; then
 		panic "tldr page for command $Cmd not found"
 	fi


### PR DESCRIPTION
Normally the message the script gives when a nonexistent command is supplied is:

```
cat: '': No such file or directory
tldr page for command foobar not found
```

this PR suppresses that cat line