### PR TITLE
fix: `installed` function should be renamed to `have`

### DIFF
--- a/tldr
+++ b/tldr
@@ -212,7 +212,7 @@ lang_cc() {
 }
 
 Get() {
-	if installed curl; then
+	if have curl; then
 		curl -sfL "$1"
 	else
 		wget -O - "$1"


### PR DESCRIPTION
Fix error: `tldr: 215: installed: not found` when running `tldr --update`. Commit c137489ca970e3d501f71bbc819667c0cd592915 renamed `installed` function declaration to `have`, but forgot to rename `installed` function to `have` in `Get` function.